### PR TITLE
Set light mode as default and hide theme toggle on mobile

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -75,26 +75,26 @@ export default function About() {
 
             <div className="prose max-w-none text-lg dark:prose-invert transition-colors duration-200">
               <p className="text-gray-500 dark:text-gray-400">
-              I was born in Hong Kong and moved to the Bay Area when I was in elementary school. My parents were an entrepreneurs who started their own business and I saw firsthand what it meant to build something from the ground up with nothing but dreams and hard work. I took that with me as a kid and was both a tinkerer and dreamy entrepreneur. At 12 years old, I created an animated movie using HyperCard on an  Apple IIGS, and I have been fascinated by computers since. When I was 17 I dabbled in art, started an apparels business and hustled graphic tees on the streets of SF. 
+              I was born in Hong Kong and moved to the Bay Area when I was in elementary school. My parents were entrepreneurs who started their own business and I saw firsthand what it meant to build something from the ground up with nothing but dreams and hard work. I took to heart my parents' journey as a kid, tinkering often with dreams of being an entrepreneur. At 12 years old, I created an animated movie using HyperCard on an Apple IIGS. When I was 17 I dabbled in art, film photography (won the class award for best photo), started an apparel business and hustled graphic tees on the streets of SF. 
               </p>
 
               <h3 className="text-sm font-medium mt-12 mb-4 text-black dark:text-white transition-colors duration-200">
                 Growing up
               </h3>
 
-              <p className="text-gray-500 dark:text-gray-400"> I've never stopped hustling, tinkering and learning since. I was briefly an industrial designer, an aspiring barista cooking up bespoke coffee recipes, and made (and sold) wallets made of recycled fabrics. 
+              <p className="text-gray-500 dark:text-gray-400"> I've never stopped hustling, tinkering and learning since. I was briefly an industrial designer and an aspiring barista cooking up bespoke coffee recipes, and I made (and sold) wallets from recycled fabrics. Through luck and hard work, I ended up working at companies like Tesla (if you bought a Model 3 in 2018-2019, I had a hand in making your car), Adobe, and Shopify.
               </p>
 
               <h3 className="text-sm font-medium mt-12 mb-4 text-black dark:text-white transition-colors duration-200">
                 What I do now
               </h3>
-              <p className="text-gray-500 dark:text-gray-400"> I'm currently a product designer at LTK leading the chat product on the consumer team. My biggest achievement this year has been picking up SwiftUI and Xcode, of which I had little prior experience. I put myself through a 30-day coding challenge and by the end of it, I was shipping code to the company repo, which has been a fun journey.
+              <p className="text-gray-500 dark:text-gray-400">I'm currently a product designer at LTK leading the chat product on the consumer team. My biggest achievement this year has been picking up SwiftUI and Xcode, both of which I had little prior experience with. I put myself through a 30-day coding challenge and by the end of it, I was shipping code to the company repo, which has been a fun journey. Oh, I also built this entire portfolio with Cursor from scratch. I get the feeling I'm gonna be building a lot more with AI. At the top of my list are a few digital art projects.
               </p>
 
               <h3 className="text-sm font-medium mt-12 mb-4 text-black dark:text-white transition-colors duration-200">
                 What design means to me
               </h3>
-              <p className="text-gray-500 dark:text-gray-400"> When people ask me what is great design, I immediately think back to the products and experiences that evoke positive memories. Great design for me isn't just about the aesthetics, it's about the emotions it evokes, and the connection it creates between the user and the product.
+              <p className="text-gray-500 dark:text-gray-400">When people ask me what great design is, I immediately think back to the products and experiences that evoke positive memories. Great design for me isn't just about the aesthetics, it's about the emotions it evokes, and the connection it creates between the user and the product.
               </p>
 
             </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout({
         className={`${inter.variable} bg-white dark:bg-black text-black dark:text-white transition-colors duration-200 custom-plus-cursor`}
       >
         <GridBackground />
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {children}
           <ThemeToggle />
         </ThemeProvider>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -15,7 +15,7 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <div className="fixed bottom-6 right-6 z-50 h-10 w-10 rounded-full bg-white shadow-md flex items-center justify-center">
+      <div className="fixed bottom-6 right-6 z-50 h-10 w-10 rounded-full bg-white shadow-md flex items-center justify-center hidden md:flex">
         <div className="h-5 w-5 bg-gray-200 rounded-full animate-pulse"></div>
       </div>
     )
@@ -24,7 +24,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="fixed bottom-6 right-6 z-50 h-10 w-10 rounded-full bg-white dark:bg-gray-800 shadow-md flex items-center justify-center transition-colors duration-200"
+      className="fixed bottom-6 right-6 z-50 h-10 w-10 rounded-full bg-white dark:bg-gray-800 shadow-md items-center justify-center transition-colors duration-200 hidden md:flex"
       aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
     >
       {theme === "dark" ? <Sun className="h-5 w-5 text-yellow-500" /> : <Moon className="h-5 w-5 text-gray-700" />}


### PR DESCRIPTION
- Change default theme from dark to light for better mobile experience
- Hide theme toggle button on mobile devices (visible on desktop only)
- Improve mobile UX by removing theme switching complexity
- Updated About page text